### PR TITLE
fix(http): ensure consistent string output from response transforms

### DIFF
--- a/rigging/generator/http.py
+++ b/rigging/generator/http.py
@@ -190,12 +190,12 @@ class HTTPSpec(BaseModel):
                 matches = [match.value for match in jsonpath_expr.find(result)]
                 if len(matches) == 0:
                     raise Exception(f"No matches found for JSONPath: {transform.pattern} from {result}")
-                result = json.dumps(matches) if len(matches) > 1 else matches[0]
+                result = json.dumps(matches) if len(matches) > 1 else str(matches[0])
 
             elif transform.type == "regex":
                 matches = re.findall(_to_str(transform.pattern), result)
                 matches = [str(match) for match in matches]
-                result = json.dumps(matches) if len(matches) > 1 else matches[0]
+                result = json.dumps(matches) if len(matches) > 1 else str(matches[0])
 
         return result
 
@@ -338,7 +338,7 @@ class HTTPGenerator(Generator):
         generated = await asyncio.gather(*coros)
 
         for i, (_messages, response) in enumerate(zip(messages, generated)):
-            trace_messages(_messages, f"Messages {i+1}/{len(messages)}")
-            trace_messages([response], f"Response {i+1}/{len(messages)}")
+            trace_messages(_messages, f"Messages {i + 1}/{len(messages)}")
+            trace_messages([response], f"Response {i + 1}/{len(messages)}")
 
         return generated

--- a/tests/test_http_spec.py
+++ b/tests/test_http_spec.py
@@ -212,3 +212,37 @@ def test_custom_header_templates() -> None:
     assert headers["Authorization"] == "Bearer test-key"
     assert headers["X-Request-ID"] == "default-id"
     assert headers["X-Model-Version"] == "test-model-v1"
+
+
+def test_parse_response_body_int() -> None:
+    spec = HTTPSpec(
+        request={
+            "url": "https://api.example.com/v1/chat",
+            "method": "POST",
+            "headers": {"Authorization": "Bearer {{api_key}}"},
+            "transforms": [{"type": "json", "pattern": {"model": "$model", "messages": "$messages"}}],
+        },
+        response={
+            "valid_status_codes": [200, 201],
+            "transforms": [{"type": "jsonpath", "pattern": "$.int_value"}],
+        },
+    )
+    result = spec.parse_response_body('{"int_value": 42}')
+    assert result == "42"
+
+
+def test_parse_response_body_list() -> None:
+    spec = HTTPSpec(
+        request={
+            "url": "https://api.example.com/v1/chat",
+            "method": "POST",
+            "headers": {"Authorization": "Bearer {{api_key}}"},
+            "transforms": [{"type": "json", "pattern": {"model": "$model", "messages": "$messages"}}],
+        },
+        response={
+            "valid_status_codes": [200, 201],
+            "transforms": [{"type": "jsonpath", "pattern": "foo[*].baz"}],
+        },
+    )
+    result = spec.parse_response_body('{"foo": [{"baz": 1}, {"baz": 2}]}')
+    assert result == "[1, 2]"


### PR DESCRIPTION
- Convert all transform outputs to strings consistently
- Add test coverage for integer response values
- Add test coverage for list response values
- Fix spacing in message logging format

The changes ensure that response transforms always return string values, fixing potential type mismatches when handling numeric or list responses.
---

## Generated Summary

- Updated the result processing in the `HTTPSpec` class to ensure consistent string representation for single match results.
- Changes made:
  - Used `str(matches[0])` instead of `matches[0]` for better type consistency.
- Added two new tests in `test_http_spec.py`:
  - `test_parse_response_body_int`: Validates parsing of an integer value from JSON response.
  - `test_parse_response_body_list`: Validates parsing of a list of values from JSON response.
- Impact:
  - These modifications enhance the robustness of response parsing, ensuring that integer and list transformations are correctly handled in the application.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
