### PR TITLE
feat(http): add configurable request timeouts

### DIFF
--- a/rigging/generator/http.py
+++ b/rigging/generator/http.py
@@ -310,7 +310,7 @@ class HTTPGenerator(Generator):
         )
 
         # Conditionally set the timeout to avoid overriding the default "unset" value
-        kwargs = {}
+        kwargs: dict[str, t.Any] = {}
         if self.spec.request.timeout is not None:
             kwargs["timeout"] = self.spec.request.timeout
         elif params.timeout is not None:

--- a/rigging/generator/http.py
+++ b/rigging/generator/http.py
@@ -101,6 +101,7 @@ class RequestSpec(BaseModel):
     url: str
     method: str = "POST"
     headers: dict[str, str] = {}
+    timeout: int | None = None
     transforms: list[TransformStep[InputTransform]] = Field(min_length=1)
 
 
@@ -308,12 +309,22 @@ class HTTPGenerator(Generator):
             model=self.model,
         )
 
+        # Conditionally set the timeout to avoid overriding the default "unset" value
+        kwargs = {}
+        if self.spec.request.timeout is not None:
+            kwargs["timeout"] = self.spec.request.timeout
+        elif params.timeout is not None:
+            kwargs["timeout"] = params.timeout
+        elif self.params.timeout is not None:
+            kwargs["timeout"] = self.params.timeout
+
         async with httpx.AsyncClient() as client:
             response = await client.request(
                 self.spec.request.method,
                 self.spec.make_url(context),
                 content=self.spec.make_request_body(context),
                 headers=self.spec.make_headers(context),
+                **kwargs,
             )
 
         content = response.text
@@ -338,7 +349,7 @@ class HTTPGenerator(Generator):
         generated = await asyncio.gather(*coros)
 
         for i, (_messages, response) in enumerate(zip(messages, generated)):
-            trace_messages(_messages, f"Messages {i+1}/{len(messages)}")
-            trace_messages([response], f"Response {i+1}/{len(messages)}")
+            trace_messages(_messages, f"Messages {i + 1}/{len(messages)}")
+            trace_messages([response], f"Response {i + 1}/{len(messages)}")
 
         return generated


### PR DESCRIPTION
- Add timeout parameter to RequestSpec
- Implement timeout hierarchy:
  1. Request spec timeout
  2. Parameter timeout
  3. Generator default timeout
- Add proper timeout forwarding to httpx client
- Fix spacing in message trace formatting

This change enables fine-grained control over HTTP request timeouts at multiple configuration levels while maintaining backward compatibility.


---

## Generated Summary

- Added a `timeout` attribute to the `RequestSpec` class, allowing customization of HTTP request timeouts.
- Updated the `HTTPGenerator` to conditionally set the `timeout` for HTTP requests based on the specified request configuration.
- Improved readability in the response tracing messages by adjusting spacing in the formatting strings.
- These changes enhance request configurability and potentially improve error handling in case of timeouts.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)


## Generated Summary

- Added a `timeout` attribute to the `RequestSpec` class to allow customizable request timeouts.
- Implemented logic in the `HTTPGenerator` class to conditionally set the timeout for HTTP requests using the `timeout` from the request specification, parameters, or defaulting if unset.
- Improved readability by adjusting the formatting in the response tracing section to maintain consistency in spacing.
- Potential impact includes enhanced control over request handling and performance tuning through timeout management.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
