### PR TITLE
test(http): ensure JSONPath transform outputs valid JSON

### DIFF
--- a/rigging/generator/http.py
+++ b/rigging/generator/http.py
@@ -191,7 +191,7 @@ class HTTPSpec(BaseModel):
                 matches = [match.value for match in jsonpath_expr.find(result)]
                 if len(matches) == 0:
                     raise Exception(f"No matches found for JSONPath: {transform.pattern} from {result}")
-                result = json.dumps(matches) if len(matches) > 1 else str(matches[0])
+                result = json.dumps(matches) if len(matches) > 1 else json.dumps(matches[0])
 
             elif transform.type == "regex":
                 matches = re.findall(_to_str(transform.pattern), result)


### PR DESCRIPTION
- Fixes the JSONPath transform to always output valid JSON string responses. 
- Added tests to verify single value handling and JSON serialization.

---

## Generated Summary

- Updated the handling of single match results in `HTTPSpec` to ensure consistency in output.
- Changed the line from:
  - `result = json.dumps(matches) if len(matches) > 1 else str(matches[0])`
  - to `result = json.dumps(matches) if len(matches) > 1 else json.dumps(matches[0])`
- This modification ensures that individual results are also returned in JSON format rather than as a string.
- Added new tests for `parse_single_value_response_body` and `test_jsonpath_transform_into_json` to validate the updated behavior.
- Both tests verify that single and multi-value JSONPath transformations are handled correctly.
- Enhancements in tests provide better coverage for response parsing, ensuring robustness in the codebase.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
