### PR TITLE
feat: add robopages native tool server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Want more?
 - OverTheWire Bandit Agent: [**bandit.py**](examples/bandit.py)
 - Damn Vulnerable Restaurant Agent: [**dvra.py**](examples/dvra.py)
 - RAG Pipeline: [**rag.py**](examples/rag.py) (from [kyleavery](https://github.com/kyleavery/))
- 
+- Integrating dreadnode-owned [robopages](https://github.com/dreadnode/robopages-cli) as a tool server (basic nmap scan example): [**rigging_example.py**](https://github.com/dreadnode/robopages-cli/blob/main/examples/rigging_example.py)
+
 ## Documentation
 
 **[docs.dreadnode.io](https://docs.dreadnode.io/open-source/rigging/intro)** has everything you need.

--- a/examples/robopages.py
+++ b/examples/robopages.py
@@ -1,0 +1,27 @@
+import asyncio
+import os
+
+import litellm
+import logfire
+
+import rigging as rg
+
+# Constants
+SYSTEM_PROMPT = "Enumerate all open TCP ports on 127.0.0.1 and provide a vulnerability report"
+
+# LOGFIRE_PROJECT = "rigging-demos"
+logfire.configure()
+os.environ.setdefault("LOGFIRE_TOKEN", "")  # (1)!
+litellm.callbacks = ["logfire"]
+
+rg.logging.configure_logging("debug")
+
+
+async def main():
+    tools = rg.integrations.robopages("http://localhost:8000")
+    chat = await rg.get_generator("gpt-4").chat(SYSTEM_PROMPT).using(*tools).run()
+    print(chat.conversation)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Notes

- new release with a native robopages tool on 2.3.0 -> https://pypi.org/project/rigging/2.3.0/
- very vanilla example here but you get the idea 
- i also fixed the `robopages-cli` repo example in https://github.com/dreadnode/robopages-cli/pull/16


---

## Generated Summary

- Added a new example script `robopages.py` demonstrating integration with the `robopages` tool.
- Updated `README.md` to include a reference to the new `rigging_example.py` example from the `robopages-cli`.
- Introduced logging configuration using `logfire` and a system prompt for enumerating TCP ports and generating a vulnerability report.
- Enhanced user experience by providing practical examples on how to utilize new integration features.
- Potential to streamline vulnerability scanning processes within the existing framework.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)
