### PR TITLE
chore: add renovate bot for deps in rigging

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,52 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:base",
+    ":disableRateLimiting",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":enablePreCommit",
+    ":automergeDigest",
+    ":automergeBranch",
+  ],
+  dependencyDashboardTitle: "Renovate Dashboard 🤖",
+  suppressNotifications: ["prIgnoreNotification"],
+  rebaseWhen: "conflicted",
+  commitBodyTable: true,
+  "pre-commit": {
+    enabled: true,
+  },
+  poetry: {
+    fileMatch: ["pyproject.toml"],
+  },
+  pip_requirements: {
+    fileMatch: [
+      "requirements-test.txt",
+      "requirements-composer.txt",
+      "constraints.txt",
+      "constraints-test.txt",
+    ],
+  },
+  packageRules: [
+    {
+      matchManagers: ["poetry", "pip_requirements"],
+      matchPackagePatterns: ["^pytest"],
+      groupName: "pytest packages",
+      groupSlug: "pytest",
+      separateMinorPatch: true,
+    },
+    {
+      matchManagers: ["poetry", "pip_requirements"],
+      matchDepTypes: ["python"],
+      allowedVersions: "^3.9",
+      enabled: true,
+    },
+    {
+      description: "Auto merge non-major updates",
+      matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      automergeType: "pr",
+    },
+  ],
+  ignorePaths: [],
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,87 @@
+---
+name: Renovate
+on:
+  # checkov:skip=CKV_GHA_7: "Workflow dispatch inputs are required for manual debugging and configuration"
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: Dry Run
+        default: "false"
+        required: false
+      logLevel:
+        description: Log Level
+        default: "debug"
+        required: false
+      version:
+        description: Renovate version
+        default: latest
+        required: false
+  schedule:
+    # Run every evening at 20:00 UTC (8:00 PM UTC)
+    - cron: "0 20 * * *"
+  push:
+    branches: ["main"]
+    paths:
+      - .github/renovate.json5
+      - .github/renovate/**.json5
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_number || github.ref }}
+  cancel-in-progress: true
+
+# Retrieve BOT_USER_ID via `curl -s "https://api.github.com/users/${BOT_USERNAME}%5Bbot%5D" | jq .id`
+env:
+  WORKFLOW_DRY_RUN: false
+  WORKFLOW_LOG_LEVEL: debug
+  WORKFLOW_VERSION: latest # 37.59.8
+  RENOVATE_PLATFORM: github
+  RENOVATE_PLATFORM_COMMIT: true
+  RENOVATE_ONBOARDING_CONFIG_FILE_NAME: .github/renovate.json5
+  RENOVATE_AUTODISCOVER: true
+  RENOVATE_AUTODISCOVER_FILTER: "${{ github.repository }}"
+  RENOVATE_GIT_AUTHOR: "${{ secrets.BOT_USERNAME }} <${{ secrets.BOT_USER_ID }}+${{ secrets.BOT_USERNAME }}[bot]@users.noreply.github.com>"
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: "${{ secrets.BOT_APP_ID }}"
+          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: "${{ steps.app-token.outputs.token }}"
+
+      - name: Override default config from dispatch variables
+        run: |
+          echo "RENOVATE_DRY_RUN=${{ github.event.inputs.dryRun || env.WORKFLOW_DRY_RUN }}" >> "${GITHUB_ENV}"
+          echo "LOG_LEVEL=${{ github.event.inputs.logLevel || env.WORKFLOW_LOG_LEVEL }}" >> "${GITHUB_ENV}"
+
+      - name: Delete old dashboard
+        run: |
+          ISSUE_NUMBER=$(gh issue list -S 'Renovate Dashboard 🤖' --json number -q '.[0].number')
+          if [ "$ISSUE_NUMBER" != "null" ] && [ -n "$ISSUE_NUMBER" ]; then
+            gh issue close "$ISSUE_NUMBER"
+          else
+            echo "No issue found to close."
+          fi
+        env:
+          GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"
+
+      - name: Renovate
+        uses: renovatebot/github-action@19e3d87179488d6a0cd9da744d37123ea4b338e5 # v41.0.20
+        with:
+          configurationFile: "${{ env.RENOVATE_ONBOARDING_CONFIG_FILE_NAME }}"
+          token: "${{ steps.app-token.outputs.token }}"
+          renovate-version: "${{ github.event.inputs.version || env.WORKFLOW_VERSION }}"


### PR DESCRIPTION
## Notes

- adds renovate bot to rigging to take care of rigging deps
- tagging @monoxgas for review for [here](https://github.com/dreadnode/rigging/blob/32f6ca5c593f65b3c4d990009be46eafb768a0e4/.github/renovate.json5#L45-L51) RE current approach to automerge minor and patches once approved. Please let me know if this is too aggressive and we can tune accordingly:

```json
    {
      description: "Auto merge non-major updates",
      matchUpdateTypes: ["minor", "patch"],
      automerge: true,
      automergeType: "pr",
    },
```


---

## Generated Summary

This PR introduces a comprehensive setup for Renovate to automate dependency updates.

- Added a new configuration file `.github/renovate.json5` with base settings tailored for our project.
- Configured key features:
  - Dependency dashboard for better visibility.
  - Automated merging of non-major updates to streamline dependency management.
  - Specific rules for handling `pytest` packages and Python version constraints.
- Established a new GitHub Actions workflow in `.github/workflows/renovate.yaml`:
  - Scheduled to run daily at 20:00 UTC to check for updates.
  - Supports manual triggering with options for dry run and log level.
  - Deletes previous Renovate dashboard issues to keep the list manageable.
- The workflow leverages a GitHub App token for authentication, enhancing security for the automation process.

These changes aim to improve our dependency management process while ensuring that we remain on top of essential updates.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)
