### PR TITLE
Add LRU cache for `get_generator` Functionality

### DIFF
--- a/rigging/generator/base.py
+++ b/rigging/generator/base.py
@@ -2,6 +2,7 @@ import abc
 import inspect
 import typing as t
 from dataclasses import dataclass, field
+from functools import lru_cache
 
 from loguru import logger
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
@@ -27,8 +28,7 @@ T = t.TypeVar("T")
 
 @t.runtime_checkable
 class LazyGenerator(t.Protocol):
-    def __call__(self) -> type["Generator"]:
-        ...
+    def __call__(self) -> type["Generator"]: ...
 
 
 g_providers: dict[str, type["Generator"] | LazyGenerator] = {}
@@ -483,16 +483,14 @@ class Generator(BaseModel):
         self,
         messages: t.Sequence[MessageDict],
         params: GenerateParams | None = None,
-    ) -> "ChatPipeline":
-        ...
+    ) -> "ChatPipeline": ...
 
     @t.overload
     def chat(
         self,
         messages: t.Sequence[Message] | MessageDict | Message | str | None = None,
         params: GenerateParams | None = None,
-    ) -> "ChatPipeline":
-        ...
+    ) -> "ChatPipeline": ...
 
     def chat(
         self,
@@ -575,8 +573,7 @@ def chat(
     generator: Generator,
     messages: t.Sequence[MessageDict],
     params: GenerateParams | None = None,
-) -> "ChatPipeline":
-    ...
+) -> "ChatPipeline": ...
 
 
 @t.overload
@@ -584,8 +581,7 @@ def chat(
     generator: Generator,
     messages: t.Sequence[Message] | MessageDict | Message | str | None = None,
     params: GenerateParams | None = None,
-) -> "ChatPipeline":
-    ...
+) -> "ChatPipeline": ...
 
 
 def chat(
@@ -663,6 +659,7 @@ def get_identifier(generator: Generator, params: GenerateParams | None = None) -
     return identifier
 
 
+@lru_cache(maxsize=128)
 def get_generator(identifier: str, *, params: GenerateParams | None = None) -> Generator:
     """
     Get a generator by an identifier string. Uses LiteLLM by default.


### PR DESCRIPTION
## Notes
- Minor Performance Improvement: Avoids redundant computations for frequently used generators in a pipeline.
---

## Generated Summary

- Introduced `lru_cache` for the `get_generator` function to optimize performance by caching results of expensive function calls.
- Cleaned up method signatures across `Generator` and `chat` methods for improved clarity.
- Adjusted type annotation formatting for consistency and readability.
- No functional changes were made to the logic; the modifications primarily streamline the codebase and enhance efficiency.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)
