### PR TITLE
fix: Tool Calling w/ Parsing

### DIFF
--- a/rigging/__init__.py
+++ b/rigging/__init__.py
@@ -14,6 +14,7 @@ from rigging.completion import (
     MapCompletionCallback,
     ThenCompletionCallback,
 )
+from rigging.error import Stop
 from rigging.generator import (
     GeneratedMessage,
     GeneratedText,
@@ -64,6 +65,7 @@ __all__ = [
     "PipelineStepContextManager",
     "PipelineStepGenerator",
     "Prompt",
+    "Stop",
     "ThenChatCallback",
     "ThenCompletionCallback",
     "Tool",

--- a/rigging/error.py
+++ b/rigging/error.py
@@ -14,6 +14,38 @@ if t.TYPE_CHECKING:
     from rigging.message import Message
 
 
+# User Throwable Exceptions
+
+
+class Stop(Exception):  # noqa: N818
+    """
+    Raise inside a pipeline to indicate a stopping condition.
+
+    Example:
+        ```
+        import rigging as rg
+
+        async def read_file(path: str) -> str:
+            "Read the contents of a file."
+
+            if no_more_files(path):
+                raise rg.Stop("There are no more files to read.")
+
+            ...
+
+        chat = await pipeline.using(read_file).run()
+        ```
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+        """The message associated with the stop."""
+
+
+# System Exceptions
+
+
 class UnknownToolError(Exception):
     """
     Raised when the an api tool call is made for an unknown tool.

--- a/rigging/prompt.py
+++ b/rigging/prompt.py
@@ -1212,7 +1212,10 @@ def prompt(
 
 @t.overload
 def make_prompt(
-    content: str, return_type: type[R], *, ctx: Ctx | None = None
+    content: str,
+    return_type: type[R],
+    *,
+    ctx: Ctx | None = None,
 ) -> Prompt[..., R]: ...
 
 

--- a/rigging/prompt.py
+++ b/rigging/prompt.py
@@ -566,14 +566,14 @@ class Prompt(t.Generic[P, R]):
             next_pipeline.add(
                 Message.from_model(
                     ValidationErrorModel(content=str(e)),
-                    suffix="Rewrite your entire message with all the required xml structure.",
+                    suffix="Rewrite your entire message with all of the required xml elements.",
                 ),
             )
         except Exception as e:  # noqa: BLE001
             next_pipeline.add(
                 Message.from_model(
                     SystemErrorModel(content=str(e)),
-                    suffix="Rewrite your entire message with all the required xml structure.",
+                    suffix="Rewrite your entire message with all of the required xml elements.",
                 ),
             )
         else:  # parsed successfully
@@ -1084,8 +1084,7 @@ def prompt(
     generator_id: str | None = None,
     tools: list[Tool[..., t.Any] | t.Callable[..., t.Any]] | None = None,
     system_prompt: str | None = None,
-) -> t.Callable[[t.Callable[P, t.Coroutine[t.Any, t.Any, R]] | t.Callable[P, R]], Prompt[P, R]]:
-    ...
+) -> t.Callable[[t.Callable[P, t.Coroutine[t.Any, t.Any, R]] | t.Callable[P, R]], Prompt[P, R]]: ...
 
 
 @t.overload
@@ -1098,8 +1097,7 @@ def prompt(
     generator_id: str | None = None,
     tools: list[Tool[..., t.Any] | t.Callable[..., t.Any]] | None = None,
     system_prompt: str | None = None,
-) -> Prompt[P, R]:
-    ...
+) -> Prompt[P, R]: ...
 
 
 @t.overload
@@ -1112,8 +1110,7 @@ def prompt(
     generator_id: str | None = None,
     tools: list[Tool[..., t.Any] | t.Callable[..., t.Any]] | None = None,
     system_prompt: str | None = None,
-) -> Prompt[P, R]:
-    ...
+) -> Prompt[P, R]: ...
 
 
 def prompt(
@@ -1214,8 +1211,9 @@ def prompt(
 
 
 @t.overload
-def make_prompt(content: str, return_type: type[R], *, ctx: Ctx | None = None) -> Prompt[..., R]:
-    ...
+def make_prompt(
+    content: str, return_type: type[R], *, ctx: Ctx | None = None
+) -> Prompt[..., R]: ...
 
 
 @t.overload
@@ -1224,8 +1222,7 @@ def make_prompt(
     return_type: None = None,
     *,
     ctx: Ctx | None = None,
-) -> Prompt[..., str]:
-    ...
+) -> Prompt[..., str]: ...
 
 
 def make_prompt(

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -223,9 +223,9 @@ class TestToolHandleCall:
             ),
         )
 
-        message, should_continue = await sample_tool.handle_tool_call(tool_call)
+        message, stop = await sample_tool.handle_tool_call(tool_call)
 
-        assert should_continue is True
+        assert stop is False
         assert message is not None
         assert message.role == "tool"
         assert message.tool_call_id == "call123"
@@ -245,9 +245,9 @@ class TestToolHandleCall:
             ).strip(),
         )
 
-        message, should_continue = await sample_tool.handle_tool_call(tool_call)
+        message, stop = await sample_tool.handle_tool_call(tool_call)
 
-        assert should_continue is True
+        assert stop is False
         assert message is not None
         assert message.role == "user"
         assert message.content == '<tool-result name="calculator">8</tool-result>'
@@ -260,9 +260,9 @@ class TestToolHandleCall:
             parameters=json.dumps({"a": 4, "b": 4, "operation": "add"}),
         )
 
-        message, should_continue = await sample_tool.handle_tool_call(tool_call)
+        message, stop = await sample_tool.handle_tool_call(tool_call)
 
-        assert should_continue is True
+        assert stop is False
         assert message is not None
         assert message.role == "user"
         assert message.content == '<tool-result name="calculator">8</tool-result>'
@@ -378,7 +378,7 @@ async def test_tool_error_catching() -> None:
 
     tool = Tool.from_callable(faulty_function, catch={ValueError})
 
-    message, should_continue = await tool.handle_tool_call(tool_call)
+    message, stop = await tool.handle_tool_call(tool_call)
 
-    assert should_continue is True
+    assert stop is False
     assert "This is a test error" in message.content


### PR DESCRIPTION
## Notes

In general attempting to make the mixed form behavior of tool calls (xml especially) with parsing logic.

- Cleaned some internal cloning behavior when it comes to callbacks.
- Removed `None` behavior being used to indicate tool call stopping conditions
- Added new Stop exception for breaking from recursive tool calls.
- Some small adjustments here and there.



---

## Generated Summary

- Introduced a new `Stop` exception in `rigging.error.py` to indicate a stopping condition within the pipeline.
- Changed variable names related to stopping tool calls in `rigging/chat.py` for clarity:
  - `stop_on_tool_calls` to `add_tool_stop_token`.
  - Updated method signatures and internal logic to utilize `add_tool_stop_token`.
- Enhanced the `ChatPipeline.clone` method to allow selective cloning of callbacks, thereby providing more control during pipeline instantiation.
- Updated various method implementations (e.g., `_then_tools`, `_then_parse`) to utilize the new stopping mechanism.
- Adjusted handling of tool calls in the `Tool` class to return a stop condition instead of a boolean to streamline flow control.
- Updated tests in `tests/test_tool.py` to reflect changes in method signatures and assert logic that checks the new stop return value instead of continuation.
- Various improvements in error messages in `rigging/prompt.py` for better user guidance.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Introduced `Stop` class to manage stopping conditions within pipelines.
- Replaced `stop_on_tool_calls` with `add_tool_stop_token` for improved clarity in the `ChatPipeline`.
- Enhanced `clone` method in `ChatPipeline` to control callback cloning behavior, allowing conditional cloning of callbacks based on the new `callbacks` parameter.
- Changed corresponding references throughout the `ChatPipeline` methods to accommodate new naming and logic for stopping tool calls.
- Updated method signatures in `ChatPipeline` to reflect changes, ensuring backward compatibility while enhancing functionality.
- Modified response handling in tool calls to reflect the change from `should_continue` to `stop`, simplifying control flow during tool call executions.
- Adjusted various docstrings across classes to maintain clarity and accuracy, especially concerning expected behavior with exceptions and stopping conditions.
- Added new tests to validate the updated behavior of tool calls, focusing on the `stop` condition instead of `should_continue`.

These changes improve the overall robustness and readability of the code, making it easier to manage tool calls and stopping conditions.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)
