### PR TITLE
fix: param name is proxy not proxies

### DIFF
--- a/examples/dvra.py
+++ b/examples/dvra.py
@@ -468,6 +468,7 @@ def cli(
 
     # Prepare our objects
 
+    generator = rg.get_generator(generator_id)
     client = httpx.AsyncClient(
         base_url=base_url,
         verify=False,


### PR DESCRIPTION
## Notes

- for `httpx.AsyncClient`, the correct parameter name is `proxy` (singular), not `proxies` (plural). 

```bash
TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
```



---

## Generated Summary

- Updated the proxy configuration in `dvra.py` from a tuple to a single `proxy` parameter.
- This change aligns with the latest `httpx` library usage for proxy settings.
- Improves clarity and potential functionality regarding proxy management.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Removed the line initializing the `generator` from `rg.get_generator(generator_id)`, which may affect functionality based on the generator's usage.
- Modified the `proxies` parameter to `proxy` within the `httpx.AsyncClient` initialization, potentially improving clarity and alignment with the library's expectations.
- These changes streamline the client configuration but require verification of any dependencies on the removed generator initialization to avoid breaking functionality.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)

