### PR TITLE
chore: switch generator to o3-mini

### DIFF
--- a/.hooks/generate_pr_description.py
+++ b/.hooks/generate_pr_description.py
@@ -65,7 +65,7 @@ def get_diff(base_ref: str, source_ref: str, *, exclude: list[str] | None = None
 def main(
     base_ref: str = "origin/main",
     source_ref: str = "HEAD",
-    generator_id: str = "openai/gpt-4o-mini",
+    generator_id: str = "openai/o3-mini",
     max_diff_lines: int = 10_000,
     exclude: list[str] | None = None,
 ) -> None:


### PR DESCRIPTION
## Notes

**Key Changes:**

sensical changed based on recent change in model manifest https://community.openai.com/t/openai-dropped-price-of-o3/1284255

- [ ] updates rigging PR decorator agent generator ID to `o3-mini`


---

## Generated Summary

- Changed default generator ID from "openai/gpt-4o-mini" to "openai/o3-mini" in the PR description generator script.
- Update ensures that the generator uses the new configuration when comparing diffs.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)

