### PR TITLE
fix: typing check for transformers

### DIFF
--- a/docs/api/data.mdx
+++ b/docs/api/data.mdx
@@ -258,7 +258,7 @@ chats\_to\_tokens
 ```python
 chats_to_tokens(
     chat: Chat,
-    tokenizer: AutoTokenizer,
+    tokenizer: PreTrainedTokenizerBase,
     *,
     apply_chat_template_kwargs: dict[str, Any]
     | None = None,
@@ -275,7 +275,7 @@ Transform a chat into a tokenized format with structured slices.
   (`Chat`)
   –The chat object to tokenize.
 * **`tokenizer`**
-  (`AutoTokenizer`)
+  (`PreTrainedTokenizerBase`)
   –The tokenizer to use for encoding and decoding.
 
 **Returns:**
@@ -287,7 +287,7 @@ Transform a chat into a tokenized format with structured slices.
 ```python
 async def chats_to_tokens(
     chat: Chat,
-    tokenizer: AutoTokenizer,
+    tokenizer: "PreTrainedTokenizerBase",
     *,
     apply_chat_template_kwargs: dict[str, t.Any] | None = None,
     encode_kwargs: dict[str, t.Any] | None = None,
@@ -323,8 +323,9 @@ async def chats_to_tokens(
         if chat.params and chat.params.tools
         else None
     )
+    # the tools above return dict[str, Any], but Transformers expects list[dict[Any, Any]]
 
-    chat_text = tokenizer.apply_chat_template(messages, tools=tools, **apply_chat_template_kwargs)
+    chat_text = tokenizer.apply_chat_template(messages, tools=tools, **apply_chat_template_kwargs)  # type: ignore[arg-type]
     chat_tokens = tokenizer.encode(chat_text, **encode_kwargs)
 
     slices: list[TokenSlice] = []
@@ -334,7 +335,13 @@ async def chats_to_tokens(
     for message in chat.all:
         # Find this message
         if not (
-            match := find_in_tokens(message.content, chat_tokens, tokenizer.decode, 0, search_start)
+            match := find_in_tokens(
+                message.content,
+                chat_tokens,
+                lambda tokens: tokenizer.decode(tokens),
+                0,
+                search_start,
+            )
         ):
             warnings.warn(
                 f"Warning: Could not find message '{message.content[:50]}...' in chat tokens",
@@ -370,7 +377,7 @@ async def chats_to_tokens(
             part_match = find_in_tokens(
                 part_text,
                 message_tokens,
-                tokenizer.decode,
+                lambda tokens: tokenizer.decode(tokens),
                 msg_start,
                 part_search_start,
             )
@@ -399,8 +406,9 @@ async def chats_to_tokens(
         # Continue searching after this message
         search_start = msg_end
 
+    # we ask for a string by default in apply_chat_template_kwargs with the tokenize=False
     return TokenizedChat(
-        text=chat_text,
+        text=chat_text,  # type: ignore[arg-type]
         tokens=chat_tokens,
         slices=slices,
         obj=chat,

--- a/docs/api/data.mdx
+++ b/docs/api/data.mdx
@@ -257,7 +257,7 @@ chats\_to\_tokens
 
 ```python
 chats_to_tokens(
-    chat: Chat | None,
+    chat: Chat,
     tokenizer: AutoTokenizer,
     *,
     apply_chat_template_kwargs: dict[str, Any]
@@ -272,7 +272,7 @@ Transform a chat into a tokenized format with structured slices.
 **Parameters:**
 
 * **`chat`**
-  (`Chat | None`)
+  (`Chat`)
   –The chat object to tokenize.
 * **`tokenizer`**
   (`AutoTokenizer`)
@@ -286,7 +286,7 @@ Transform a chat into a tokenized format with structured slices.
 <Accordion title="Source code in rigging/data.py" icon="code">
 ```python
 async def chats_to_tokens(
-    chat: Chat | None,
+    chat: Chat,
     tokenizer: AutoTokenizer,
     *,
     apply_chat_template_kwargs: dict[str, t.Any] | None = None,

--- a/docs/api/tokenize.mdx
+++ b/docs/api/tokenize.mdx
@@ -12,7 +12,7 @@ get\_tokenizer
 ```python
 get_tokenizer(
     tokenizer_id: str, **tokenizer_kwargs: Any
-) -> AutoTokenizer | None
+) -> t.Any
 ```
 
 Get the tokenizer from transformers model identifier, or from an already loaded tokenizer.
@@ -30,7 +30,7 @@ Get the tokenizer from transformers model identifier, or from an already loaded 
 
 **Returns:**
 
-* `AutoTokenizer | None`
+* `Any`
   –An instance of `AutoTokenizer`.
 
 <Accordion title="Source code in rigging/tokenize/tokenizer.py" icon="code">
@@ -38,7 +38,7 @@ Get the tokenizer from transformers model identifier, or from an already loaded 
 def get_tokenizer(
     tokenizer_id: str,
     **tokenizer_kwargs: t.Any,
-) -> AutoTokenizer | None:
+) -> t.Any:
     """
     Get the tokenizer from transformers model identifier, or from an already loaded tokenizer.
 
@@ -49,18 +49,20 @@ def get_tokenizer(
     Returns:
         An instance of `AutoTokenizer`.
     """
-    tokenizer: AutoTokenizer | None = None
-
     try:
+        from transformers import AutoTokenizer
+
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_id,
             **tokenizer_kwargs,
         )
         logger.success(f"Loaded tokenizer for model '{tokenizer_id}'")
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         # Catch all exceptions to handle any issues with loading the tokenizer
-        logger.error(f"Failed to load tokenizer for model '{tokenizer_id}': {e}")
+        raise RuntimeError(
+            f"Failed to load tokenizer for model '{tokenizer_id}': {e}",
+        ) from e
 
     return tokenizer
 ```

--- a/rigging/data.py
+++ b/rigging/data.py
@@ -294,7 +294,7 @@ async def chats_to_elastic(
 
 
 async def chats_to_tokens(
-    chat: Chat | None,
+    chat: Chat,
     tokenizer: AutoTokenizer,
     *,
     apply_chat_template_kwargs: dict[str, t.Any] | None = None,

--- a/rigging/data.py
+++ b/rigging/data.py
@@ -12,13 +12,15 @@ import elasticsearch.helpers
 import pandas as pd
 from elastic_transport import ObjectApiResponse
 from mypy_boto3_s3 import S3Client
-from transformers import AutoTokenizer
 
 from rigging.chat import Chat
 from rigging.error import TokenizeWarning
 from rigging.message import Message
 from rigging.tokenize import find_in_tokens
 from rigging.tokenize.base import TokenizedChat, TokenSlice
+
+if t.TYPE_CHECKING:
+    from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 
 def flatten_chats(chats: Chat | t.Sequence[Chat]) -> list[dict[t.Any, t.Any]]:
@@ -295,7 +297,7 @@ async def chats_to_elastic(
 
 async def chats_to_tokens(
     chat: Chat,
-    tokenizer: AutoTokenizer,
+    tokenizer: "PreTrainedTokenizerBase",
     *,
     apply_chat_template_kwargs: dict[str, t.Any] | None = None,
     encode_kwargs: dict[str, t.Any] | None = None,
@@ -331,8 +333,9 @@ async def chats_to_tokens(
         if chat.params and chat.params.tools
         else None
     )
+    # the tools above return dict[str, Any], but Transformers expects list[dict[Any, Any]]
 
-    chat_text = tokenizer.apply_chat_template(messages, tools=tools, **apply_chat_template_kwargs)
+    chat_text = tokenizer.apply_chat_template(messages, tools=tools, **apply_chat_template_kwargs)  # type: ignore[arg-type]
     chat_tokens = tokenizer.encode(chat_text, **encode_kwargs)
 
     slices: list[TokenSlice] = []
@@ -342,7 +345,13 @@ async def chats_to_tokens(
     for message in chat.all:
         # Find this message
         if not (
-            match := find_in_tokens(message.content, chat_tokens, tokenizer.decode, 0, search_start)
+            match := find_in_tokens(
+                message.content,
+                chat_tokens,
+                lambda tokens: tokenizer.decode(tokens),
+                0,
+                search_start,
+            )
         ):
             warnings.warn(
                 f"Warning: Could not find message '{message.content[:50]}...' in chat tokens",
@@ -378,7 +387,7 @@ async def chats_to_tokens(
             part_match = find_in_tokens(
                 part_text,
                 message_tokens,
-                tokenizer.decode,
+                lambda tokens: tokenizer.decode(tokens),
                 msg_start,
                 part_search_start,
             )
@@ -407,8 +416,9 @@ async def chats_to_tokens(
         # Continue searching after this message
         search_start = msg_end
 
+    # we ask for a string by default in apply_chat_template_kwargs with the tokenize=False
     return TokenizedChat(
-        text=chat_text,
+        text=chat_text,  # type: ignore[arg-type]
         tokens=chat_tokens,
         slices=slices,
         obj=chat,

--- a/rigging/tokenize/tokenizer.py
+++ b/rigging/tokenize/tokenizer.py
@@ -1,12 +1,17 @@
-import importlib.util
 import typing as t
+from typing import TYPE_CHECKING
 
-if importlib.util.find_spec("transformers") is None:
-    raise ModuleNotFoundError("Please install the `transformers` package to use this module.")
-
+if TYPE_CHECKING:
+    from transformers import AutoTokenizer
 
 from loguru import logger
-from transformers import AutoTokenizer
+
+try:
+    from transformers import AutoTokenizer
+except ImportError:
+    raise ModuleNotFoundError(
+        "Please install the `transformers` package to use this module."
+    ) from None
 
 from rigging.tokenize.base import Decoder
 

--- a/rigging/tokenize/tokenizer.py
+++ b/rigging/tokenize/tokenizer.py
@@ -10,7 +10,7 @@ try:
     from transformers import AutoTokenizer
 except ImportError:
     raise ModuleNotFoundError(
-        "Please install the `transformers` package to use this module."
+        "Please install the `transformers` package to use this module.",
     ) from None
 
 from rigging.tokenize.base import Decoder

--- a/rigging/tokenize/tokenizer.py
+++ b/rigging/tokenize/tokenizer.py
@@ -1,17 +1,6 @@
 import typing as t
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from transformers import AutoTokenizer
 
 from loguru import logger
-
-try:
-    from transformers import AutoTokenizer
-except ImportError:
-    raise ModuleNotFoundError(
-        "Please install the `transformers` package to use this module.",
-    ) from None
 
 from rigging.tokenize.base import Decoder
 
@@ -19,7 +8,7 @@ from rigging.tokenize.base import Decoder
 def get_tokenizer(
     tokenizer_id: str,
     **tokenizer_kwargs: t.Any,
-) -> AutoTokenizer | None:
+) -> t.Any:
     """
     Get the tokenizer from transformers model identifier, or from an already loaded tokenizer.
 
@@ -30,18 +19,20 @@ def get_tokenizer(
     Returns:
         An instance of `AutoTokenizer`.
     """
-    tokenizer: AutoTokenizer | None = None
-
     try:
+        from transformers import AutoTokenizer
+
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_id,
             **tokenizer_kwargs,
         )
         logger.success(f"Loaded tokenizer for model '{tokenizer_id}'")
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         # Catch all exceptions to handle any issues with loading the tokenizer
-        logger.error(f"Failed to load tokenizer for model '{tokenizer_id}': {e}")
+        raise RuntimeError(
+            f"Failed to load tokenizer for model '{tokenizer_id}': {e}",
+        ) from e
 
     return tokenizer
 


### PR DESCRIPTION
## Notes

Transformers is not currently a default install, but tokenize.py imported it directly. Added a check to ensure transformers is installed before import. 




---

## Generated Summary

- Updated function signatures to enforce a non-optional Chat and require a PreTrainedTokenizerBase instead of AutoTokenizer, ensuring stricter type safety.
- Modified return types for get_tokenizer functions in both docs and source files to use t.Any, reflecting more flexible tokenizer outputs.
- Changed error handling in get_tokenizer implementations to raise a RuntimeError (with exception chaining) instead of logging errors.
- Wrapped tokenizer.decode calls in lambda functions for proper function signature alignment in find_in_tokens usage.
- Removed the explicit check for the transformers package in the tokenizer module, simplifying import logic.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Changed the function signature for chats_to_tokens in both docs and code to require a Chat object rather than allowing None.
- Updated the type annotations consistently across documentation and implementation to enforce the required Chat parameter.
- Modified the import logic for AutoTokenizer in rigging/tokenize/tokenizer.py by replacing the direct import with a try/except block and using TYPE_CHECKING for improved type hints.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Changed module import strategy for AutoTokenizer from the transformers package:
  - Removed the initial find_spec check and moved to a try/except block.
  - Wrapped the type checking import for AutoTokenizer inside a TYPE_CHECKING conditional.
- Ensured a clear error message is raised when the transformers package is not installed.
- Simplified import logic by removing redundant code.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Replaced the use of importlib.util for checking the existence of the transformers package with a try/except block.
- Added a TYPE_CHECKING conditional import for AutoTokenizer to support type hints without triggering the import during runtime.
- Simplified error handling by raising a ModuleNotFoundError directly when the transformers package is not installed.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)
