### PR TITLE
Fix unhashable GenerateParams

### DIFF
--- a/rigging/generator/base.py
+++ b/rigging/generator/base.py
@@ -257,6 +257,12 @@ class GenerateParams(BaseModel):
         """
         return self.model_copy(deep=True)
 
+    def __hash__(self) -> int:
+        """
+        Create a hash based on the json representation of this object.
+        """
+        return hash(self.model_dump_json())
+
 
 StopReason = t.Literal["stop", "length", "content_filter", "tool_calls", "unknown"]
 """Reporting reason for generation completing."""


### PR DESCRIPTION
Hi, with the latest version of rigging if you provide any 'GenerateParams' to the get_generator function it will throw this error:

`TypeError: unhashable type: 'GenerateParams'`

This PR adds a simple `__hash__` function to `GenerateParams` to make sure this object is hashable and it will work with the `lru_cache` decorator.

## Notes


---
