### PR TITLE
fix: CDATA Escaping

### DIFF
--- a/docs/api/model.mdx
+++ b/docs/api/model.mdx
@@ -490,9 +490,17 @@ def preprocess_with_cdata(cls, content: str) -> str:
         return f"<{field_name}{tag_attrs}>{content}</{field_name}>"
 
     fields_pattern = "|".join(re.escape(field_name) for field_name in field_map)
-    pattern = f"<({fields_pattern})((?:[^>]*?)?)>(.*?)</\\1>"
+    pattern = f"<({fields_pattern})((?:\\s[^>]*?)?)>(.*?)</\\1>"
 
-    return re.sub(pattern, wrap_with_cdata, content, flags=re.DOTALL)
+    updated = re.sub(pattern, wrap_with_cdata, content, flags=re.DOTALL)
+
+    # If our updates created invalid XML, discard them
+    try:
+        ET.fromstring(updated)  # noqa: S314 # nosec
+    except ET.ParseError:
+        return content
+
+    return updated
 ```
 
 


### PR DESCRIPTION
## Notes

- Fix a bug in CDATA auto-insertion that could cause failures


---

## Generated Summary

- Updated regex pattern in both docs/api/model.mdx and rigging/model.py to require a whitespace character before the tag attributes.
- Wrapped the substitution result with an XML parsing check using ET.fromstring; if invalid XML is detected, the original content is returned.
- These changes ensure that wrapping fields with CDATA does not accidentally produce malformed XML, maintaining data integrity.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)

