### PR TITLE
feat: Tools as MCP

### DIFF
--- a/docs/api/tools.mdx
+++ b/docs/api/tools.mdx
@@ -574,6 +574,105 @@ transport: Transport = transport
 ```
 
 The transport to use
+
+as\_mcp
+-------
+
+```python
+as_mcp(
+    tools: Iterable[Tool[..., Any] | Callable[..., Any]],
+    *,
+    name: str = "Rigging Tools",
+) -> FastMCP
+```
+
+Serves a collection of Rigging tools over the Model Context Protocol (MCP).
+
+This function creates a FastMCP server instance that exposes your
+Rigging tools to any compliant MCP client. It acts as a bridge, handling
+the conversion between Rigging's `Tool` objects and the MCP specification.
+
+**Parameters:**
+
+* **`tools`**
+  (`Iterable[Tool[..., Any] | Callable[..., Any]]`)
+  –An iterable of `rigging.Tool` objects or raw Python functions
+  to be exposed. If raw functions are passed, they will be
+  converted to `Tool` objects automatically.
+* **`name`**
+  (`str`, default:
+  `'Rigging Tools'`
+  )
+  –The name of the MCP server. This is used for identification
+
+Example
+
+```python
+# in my_tool_server.py
+import asyncio
+import rigging as rg
+
+@rg.tool
+def add_numbers(a: int, b: int) -> int:
+    """Adds two numbers together."""
+    return a + b
+
+if __name__ == "__main__":
+    rg.as_mcp([add_numbers]).run(
+        transport="stdio"
+    )
+```
+
+
+<Accordion title="Source code in rigging/tools/mcp.py" icon="code">
+```python
+def as_mcp(
+    tools: t.Iterable[Tool[..., t.Any] | t.Callable[..., t.Any]],
+    *,
+    name: str = "Rigging Tools",
+) -> "FastMCP":
+    """
+    Serves a collection of Rigging tools over the Model Context Protocol (MCP).
+
+    This function creates a FastMCP server instance that exposes your
+    Rigging tools to any compliant MCP client. It acts as a bridge, handling
+    the conversion between Rigging's `Tool` objects and the MCP specification.
+
+    Args:
+        tools: An iterable of `rigging.Tool` objects or raw Python functions
+               to be exposed. If raw functions are passed, they will be
+               converted to `Tool` objects automatically.
+        name: The name of the MCP server. This is used for identification
+
+    Example:
+        ~~~python
+        # in my_tool_server.py
+        import asyncio
+        import rigging as rg
+
+        @rg.tool
+        def add_numbers(a: int, b: int) -> int:
+            \"\"\"Adds two numbers together.\"\"\"
+            return a + b
+
+        if __name__ == "__main__":
+            rg.as_mcp([add_numbers]).run(
+                transport="stdio"
+            )
+        ~~~
+    """
+    rigging_tools = [t if isinstance(t, Tool) else Tool.from_callable(t) for t in tools]
+    fastmcp_tools = [
+        FastMCPTool.from_function(
+            fn=_create_mcp_handler(tool.fn), name=tool.name, description=tool.description
+        )
+        for tool in rigging_tools
+    ]
+    return FastMCP(name, tools=fastmcp_tools)
+```
+
+
+</Accordion>
 Utilities for integrating tools from a Robopages server.
 
 robopages

--- a/docs/topics/migrations.mdx
+++ b/docs/topics/migrations.mdx
@@ -130,7 +130,7 @@ We worked hard in v3 to bring together some of the early tool systems and unify 
     - It uses a `mode: ToolMode` parameter (`auto`, `api`, `xml`, `json-in-xml`) to control calling convention.
     - It uses `max_depth: int` to limit recursive tool calls.
     - Parameters like `force`, `attempt_recovery`, `drop_dialog`, `max_rounds` are removed.
-- The `rigging.integrations` module is removed. Use `rigging.tool.robopages` and the new `rigging.tool.mcp` to use those integrations as tools.
+- The `rigging.integrations` module is removed. Use `rigging.tools.robopages` and the new `rigging.tools.mcp` to use those integrations as tools.
 
 <CodeGroup>
 ```python v2.x

--- a/docs/topics/tools.mdx
+++ b/docs/topics/tools.mdx
@@ -266,7 +266,7 @@ The [Model Context Protocol (MCP)](https://github.com/model-context-protocol/spe
 
 ### Using MCP Tools in Rigging
 
-Use the `rigging.tool.mcp` function, specifying the transport method (`stdio` or `sse`) and the connection parameters. It returns an *async context manager*.
+Use the `rigging.mcp` function, specifying the transport method (`stdio` or `sse`) and the connection parameters. It returns an *async context manager*.
 
 <CodeGroup>
 ```python Using "stdio" (Standard Input/Output)
@@ -423,7 +423,7 @@ $ claude
 
 [Robopages](https://github.com/context-labs/robopages) is a framework for building and hosting tool-enabled "pages" or APIs. Rigging can dynamically fetch the available tools from a running Robopages server and make them available to your language model.
 
-Use the `rigging.tool.robopages` function to connect to a Robopages endpoint and retrieve its tools.
+Use the `rigging.robopages` function to connect to a Robopages endpoint and retrieve its tools.
 
 ```python
 import rigging as rg

--- a/docs/topics/tools.mdx
+++ b/docs/topics/tools.mdx
@@ -264,16 +264,17 @@ This stop indication won't completely halt the pipeline, but it will let it cont
 
 The [Model Context Protocol (MCP)](https://github.com/model-context-protocol/specification) is an open standard for language models to interact with external tools and services. Rigging provides a client to connect to MCP-compliant servers.
 
+### Using MCP Tools in Rigging
+
 Use the `rigging.tool.mcp` function, specifying the transport method (`stdio` or `sse`) and the connection parameters. It returns an *async context manager*.
 
-### Using `stdio` (Standard Input/Output)
-
-Connect to an MCP server launched as a local process that communicates over standard input/output.
-
-```python
+<CodeGroup>
+```python Using "stdio" (Standard Input/Output)
 import rigging as rg
 
-# Example: Assuming 'my-mcp-server' is an executable that starts the MCP server
+# Connect to an MCP server launched as a local process that communicates over standard input/output.
+# (Assuming 'my-mcp-server' is an executable that starts the MCP server)
+
 command = "my-mcp-server"
 args = ["--port", "stdio"] # Example arguments
 
@@ -294,12 +295,10 @@ async with rg.mcp("stdio", command=command, args=args) as mcp_client:
 
 ```
 
-### Using `sse` (Server-Sent Events)
-
-Connect to an MCP server exposed via an HTTP endpoint using Server-Sent Events.
-
-```python
+```python Using "sse" (Server-Sent Events)
 import rigging as rg
+
+# Connect to an MCP server exposed via an HTTP endpoint using Server-Sent Events.
 
 # URL of the MCP SSE endpoint
 MCP_SSE_URL = "http://localhost:8001/mcp" # Example URL
@@ -321,6 +320,104 @@ async with rg.mcp("sse", url=MCP_SSE_URL) as mcp_client:
 ```
 
 The `mcp` context manager handles the connection, tool discovery, and communication with the MCP server. Inside the `async with` block, `mcp_client.tools` provides the list of discovered `Tool` objects ready to be used with `.using()`.
+
+#### Example: Using Claude Code as a Rigging Tool
+
+```python
+import rigging as rg
+
+async with rg.mcp("stdio", command="claude", args=["mcp", "serve"]) as mcp_client:
+    print(f"Discovered {len(mcp_client.tools)} tools:")
+    for tool in mcp_client.tools:
+        print(f" |- {tool.name}")
+
+    chat = (
+        await rg.get_generator("claude-3-7-sonnet-latest")
+        .chat("Using tools, create a file_writer.py rigging tool that writes to a file.")
+        .using(*mcp_client.tools)
+        .run()
+    )
+    print(chat.conversation)
+```
+
+### Serving Tools with MCP
+
+In addition to consuming tools from mcp servers, Rigging can **expose its own tools** as an MCP server. This allows you to write a singular tool implementation with the freedom to use it in other MCP-compliant clients, such as claude code.
+
+The `rigging.as_mcp` function is the primary way to create an MCP server from your tools. It takes a list of Rigging `Tool` objects (or raw Python functions) and returns a `mcp.server.fastmcp.FastMCP` server instance, which you can then configure and run.
+
+**How it works:**
+1.  You provide a list of tools to `as_mcp`.
+2.  It automatically converts raw functions into `rigging.Tool` objects.
+3.  For each tool, it creates a bridge that handles:
+    - Exposing the tool's name, description, and parameter schema.
+    - Calling your Python function when a request comes in.
+    - Converting your function's return value (including `rigging.Message` and `rigging.Stop`) into a format the MCP client can understand.
+4.  It returns a `FastMCP` server instance, ready to be run.
+
+Let's create a server that exposes a `file_writer` tool.
+
+**1. Define your tool(s) in a file (e.g., `file_writer.py`):**
+
+```python
+import rigging as rg
+from typing import Annotated
+
+@rg.tool()
+def write_file(
+    filename: Annotated[str, "The name of the file to write to."],
+    content: Annotated[str, "The content to write to the file."],
+) -> str:
+    """
+    Writes content to a local file.
+    Creates the file if it doesn't exist, and overwrites it if it does.
+    """
+    with open(filename, "w") as f:
+        f.write(content)
+    return f"Successfully wrote {len(content)} bytes to {filename}."
+
+if __name__ == "__main__":
+    # Create the MCP server instance from a list of tools
+    rg.as_mcp([write_file], name="File IO Tools").run()
+```
+
+Now, this server is ready to be used by any MCP client:
+
+- [claude-code](https://docs.anthropic.com/en/docs/claude-code/mcp)
+- [gemini-cli](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md)
+- [codex](https://github.com/openai/codex/blob/main/codex-rs/config.md#mcp_servers)
+
+**Claude Code Example:**
+
+```bash
+$ claude mcp add file_writer -- uv run --with rigging --no-project file_writer.py
+Added stdio MCP server file_writer with command: uv run --with rigging --no-project file_writer.py to local config
+
+$ claude
+> /mcp
+
+╭────────────────────────────────────────────────────────────────────────────────╮
+| Manage MCP servers                                                             │
+│                                                                                │
+│ ❯ 1. file_writer  ✔ connected · Enter to view details                          │                                                             │
+|                                                                                │
+╰────────────────────────────────────────────────────────────────────────────────╯
+
+╭────────────────────────────────────────────────────────────────────────────────╮
+│ Rigging Tools                                                                  │
+│                                                                                │
+│ Status: ✔ connected                                                            │
+│ Command: uv                                                                    │
+│ Args: run --with rigging --no-project file_writer.py                           │
+│ Config location: /Users/user/.claude.json [project: /Users/user/code]          │
+│ Capabilities: tools                                                            │
+│ Tools: 1 tools                                                                 │
+│                                                                                │
+│ ❯ 1. View tools                                                                │
+╰────────────────────────────────────────────────────────────────────────────────╯
+
+> Summarize the README file using the file_writer tool.
+```
 
 ## Robopages
 

--- a/rigging/__init__.py
+++ b/rigging/__init__.py
@@ -50,7 +50,7 @@ from rigging.message import (
 from rigging.model import Model, attr, element, wrapped
 from rigging.prompt import Ctx, Prompt, prompt
 from rigging.tokenizer import TokenizedChat, Tokenizer, get_tokenizer, register_tokenizer
-from rigging.tools import Tool, mcp, robopages, tool, tool_method
+from rigging.tools import Tool, as_mcp, mcp, robopages, tool, tool_method
 from rigging.transform import PostTransform, Transform
 from rigging.util import await_
 from rigging.version import VERSION
@@ -93,6 +93,7 @@ __all__ = [
     "Tokenizer",
     "Tool",
     "Transform",
+    "as_mcp",
     "attr",
     "await_",
     "caching",

--- a/rigging/tools/__init__.py
+++ b/rigging/tools/__init__.py
@@ -13,7 +13,7 @@ from rigging.tools.base import (
     tool,
     tool_method,
 )
-from rigging.tools.mcp import mcp
+from rigging.tools.mcp import as_mcp, mcp
 from rigging.tools.robopages import robopages
 
 __all__ = [
@@ -24,6 +24,7 @@ __all__ = [
     "ToolChoice",
     "ToolDefinition",
     "ToolMode",
+    "as_mcp",
     "mcp",
     "robopages",
     "tool",


### PR DESCRIPTION
## Notes

- Add `as_mcp` helper to turn rigging tools into a FastMCP server
- Updated docs around MCP integrations



---

## Generated Summary

- Added the new as_mcp function, which creates a FastMCP server instance from Rigging tools or raw Python functions and handles conversion to MCP-compatible types.
- Updated documentation in docs/api/tools.mdx and docs/topics/tools.mdx to include usage details, examples, and source code for as_mcp.
- Modified migration documentation to change references from rigging.integrations to rigging.tools for both MCP and Robopages integrations.
- Updated export lists in rigging/__init__.py and rigging/tools/__init__.py to expose the new as_mcp function.
- Extended the MCP communication logic in rigging/tools/mcp.py with helper methods (_convert_rigging_return_to_mcp and _create_mcp_handler) to support proper serialization of tool responses.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Introduced the new as_mcp function to create a FastMCP server from a collection of Rigging tools or raw Python functions.
- Updated documentation in both the API and topics pages to explain as_mcp usage with clear examples for exposing and consuming MCP tools.
- Modified the rigging/__init__.py and rigging/tools/__init__.py files to export the new as_mcp function.
- Enhanced the MCP module by adding helper functions (_convert_rigging_return_to_mcp and _create_mcp_handler) to properly bridge Rigging tool returns to the MCP format.
- Added detailed examples showing how to run an MCP server using as_mcp and how to connect to MCP servers using both stdio and sse transports.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)

