### PR TITLE
fix: hyperlink to robopages repo url

### DIFF
--- a/docs/topics/tools.mdx
+++ b/docs/topics/tools.mdx
@@ -422,7 +422,7 @@ $ claude
 
 ## Robopages
 
-[Robopages](https://github.com/context-labs/robopages) is a framework for building and hosting tool-enabled "pages" or APIs. Rigging can dynamically fetch the available tools from a running Robopages server and make them available to your language model.
+[Robopages](https://github.com/dreadnode/robopages) is a framework for building and hosting tool-enabled "pages" or APIs. Rigging can dynamically fetch the available tools from a running Robopages server and make them available to your language model.
 
 Use the `rigging.robopages` function to connect to a Robopages endpoint and retrieve its tools.
 


### PR DESCRIPTION
## Notes

- fixes small docs error for incorrect hyperlink to robopages


---

## Generated Summary

- Updated the Robopages repository URL from "https://github.com/context-labs/robopages" to "https://github.com/dreadnode/robopages".
- Ensured that the documentation now links to the correct GitHub repository for Robopages.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)

