### PR TITLE
chore: migrate Renovate base preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "config:base",
+    "config:recommended",
     ":disableRateLimiting",
     ":semanticCommits",
     ":enablePreCommit",


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- keep the existing rate-limit, semantic-commit, pre-commit, automerge, and manager settings unchanged

## Verification
- checked the Renovate Dashboard (#83) for the `Config Migration Needed` signal
- confirmed there were no open PRs before pushing
- `git diff --check`
- text check that `.github/renovate.json5` now uses `config:recommended` and no longer references `config:base`

This is a narrow config-only maintenance update.